### PR TITLE
Fix usvfs project dependency specification.

### DIFF
--- a/makefile.uni.py
+++ b/makefile.uni.py
@@ -99,17 +99,19 @@ if config.get('optimize', False):
     cmake_parameters.append("-DOPTIMIZE_LINK_FLAGS=\"/LTCG /INCREMENTAL:NO /OPT:REF /OPT:ICF\"")
 
 
-usvfs = Project("usvfs") \
-    .depend(cmake.CMake().arguments(cmake_parameters +
-                                    ["-DPROJ_ARCH={}".format("x86" if config['architecture'] == 'x86' else "x64")])
-            .install())
+usvfs = Project("usvfs")
 
+usvfs_build_step = cmake.CMake().arguments(cmake_parameters + ["-DPROJ_ARCH={}".format("x86" if config['architecture'] == 'x86' else "x64")])\
+    .install()
 
-usvfs.depend(patch.CreateFile("CMakeLists.txt.user", partial(gen_userfile_content, usvfs))
-             .depend(cmake.CMakeEdit(cmake.CMakeEdit.Type.CodeBlocks).arguments(cmake_parameters)
-                     .depend(github.Source("TanninOne", "usvfs", "master")
-                             .set_destination("usvfs"))
-                     .depend("AsmJit").depend("Udis86").depend("GTest")
+usvfs.depend(usvfs_build_step
+             .depend(patch.CreateFile("CMakeLists.txt.user", partial(gen_userfile_content, usvfs))
+                     .depend(cmake.CMakeEdit(cmake.CMakeEdit.Type.CodeBlocks).arguments(cmake_parameters)
+                             .depend(github.Source("TanninOne", "usvfs", "master").set_destination("usvfs"))
+                             .depend("AsmJit")
+                             .depend("Udis86")
+                             .depend("GTest")
+                             )
                      )
              )
 


### PR DESCRIPTION
Currently when running a clean clone of umbrella I get the following output from >python unimake.py -b build:

```
>python unimake.py -d b1
2016-01-07 22:30:12,028 building dependency graph
2016-01-07 22:30:12,098 processing tasks
2016-01-07 22:30:12,098 run task "retrieve codehgdev45"
adding changesets
adding manifests
adding file changes
added 2081 changesets with 11325 changes to 1685 files
updating to branch default
1512 files updated, 0 files merged, 0 files removed, 0 files unresolved

2016-01-07 22:30:32,362 run task "download udis86-1.7.2.tar.gz"
2016-01-07 22:30:32,362 processing download
2016-01-07 22:30:32,362 File not yet downloaded: b1\downloads\udis86-1.7.2.tar.gz
2016-01-07 22:30:32,362 Downloading http://downloads.sourceforge.net/project/udis86/udis86/1.7/udis86-1.7.2.tar.gz to b1\downloads\udis86-1.7.2.tar.gz
Downloading [==================================================] 100%
2016-01-07 22:30:34,101 Extracting http://downloads.sourceforge.net/project/udis86/udis86/1.7/udis86-1.7.2.tar.gz
Extracting [                                                  ] 0%%

2016-01-07 22:30:34,371 run task "download win_flex_bison-latest.zip"
2016-01-07 22:30:34,371 processing download
2016-01-07 22:30:34,371 File not yet downloaded: b1\downloads\win_flex_bison-latest.zip
2016-01-07 22:30:34,371 Downloading http://downloads.sourceforge.net/project/winflexbison/win_flex_bison-latest.zip to b1\downloads\win_flex_bison-latest.zip
Downloading [==================================================] 100%
2016-01-07 22:30:40,528 Extracting http://downloads.sourceforge.net/project/winflexbison/win_flex_bison-latest.zip
Extracting [                                                  ] 0%%

2016-01-07 22:30:40,588 run task "download 7z920.tar.bz2"
2016-01-07 22:30:40,588 processing download
2016-01-07 22:30:40,588 File not yet downloaded: b1\downloads\7z920.tar.bz2
2016-01-07 22:30:40,588 Downloading http://www.7-zip.org/a/7z920.tar.bz2 to b1\downloads\7z920.tar.bz2
Downloading [==================================================] 100%
2016-01-07 22:30:42,227 Extracting http://www.7-zip.org/a/7z920.tar.bz2
Extracting [                                                  ] 0%%

2016-01-07 22:30:43,667 run task "cmake usvfs"
2016-01-07 22:30:43,667 source path not known for usvfs, are you missing a matching retrieval script?
2016-01-07 22:30:43,667 task cmake usvfs failed

>
```

It seems that the dependencies are not added in the right order. I just made the code look like the specification inside the for loop of the other modorganizer projects.
Note - I still do not have a fully functional umbrella build so I am not 100% sure that this fully fixes the issue.
